### PR TITLE
Fixed bug causing the url to be cleared every time you refresh the page.

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -93,8 +93,8 @@ function App({ entity_type, upload_id, page, page_size, sort_field, sort_order, 
     useEffect(() => {
         let url = new URL(window.location.href);
         let info = url.searchParams.get("info");
-        window.history.pushState(null, null, `/`);
         if (info) {
+            window.history.pushState(null, null, `/`);
             localStorage.setItem("info", info);
             localStorage.setItem("isAuthenticated", "true");
             setGlobusInfo(info);


### PR DESCRIPTION
This is only meant to happen when returning from globus auth. As a consequence, using url parameters would take effect but would not show in the url. This has been fixed.