### PR TITLE
Derek furst/version 2

### DIFF
--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -104,6 +104,8 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
     if (filters.hasOwnProperty("data_types")) {
         defaultFilteredValue["data_types"] = filters["data_types"].split(",");
     }
+    const ingest_url = process.env.NEXT_PUBLIC_INGEST_URL.endsWith('/') ? process.env.NEXT_PUBLIC_INGEST_URL : process.env.NEXT_PUBLIC_INGEST_URL + '/'
+    const organ_portal_url = process.env.NEXT_PUBLIC_PORTAL_URL.endsWith('/') ? process.env.NEXT_PUBLIC_PORTAL_URL : process.env.NEXT_PUBLIC_PORTAL_URL + '/'
 
     const renderDropdownContent = (record) => (
         <Menu>
@@ -111,7 +113,7 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
                 <a href={record.portal_url} target="_blank" rel="noopener noreferrer">Data Portal</a>
             </Menu.Item>
             <Menu.Item key="2">
-                <a href={record.ingest_url} target="_blank" rel="noopener noreferrer">Ingest Portal</a>
+                <a href={ingest_url + 'dataset/' + record.uuid} target="_blank" rel="noopener noreferrer">Ingest Portal</a>
             </Menu.Item>
             <Menu.Item key="3">
                 <a href={record.globus_url} target="_blank" rel="noopener noreferrer">Globus Directory</a>
@@ -214,7 +216,7 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
                     return null;
                 }
                 return (
-                    <a href={record.organ_portal_url} target="_blank" rel="noopener noreferrer">{organHubmapId}<ExportOutlined style={{verticalAlign: 'middle'}}/></a>
+                    <a href={organ_portal_url + 'browse/sample/' + record.organ_uuid} target="_blank" rel="noopener noreferrer">{organHubmapId}<ExportOutlined style={{verticalAlign: 'middle'}}/></a>
                 );
             }
         },

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -384,7 +384,7 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
                             </CSVLink>
                         </div>
                     </div>
-                    <Table className="m-4 DatasetTable"
+                    <Table className={`m-4 UploadTable ${countFilteredRecords(data, filters).length > 0 ? '' : 'no-data'}`}
                         columns={datasetColumns}
                         dataSource={data}
                         showHeader={!loading}
@@ -600,16 +600,16 @@ const UploadTable = ({ data, loading, filterUploads, uploadData, datasetData, ha
             ) : (
                 <>
                     <div className="row">
-                        <div className="col-12 col-md-3 count mt-md-3">
-                            <span style={{ marginRight: '1rem' }}>
-                                {countFilteredRecords(data, filters).length} Selected
-                            </span>
-                            <CSVLink data={countFilteredRecords(data, filters)} filename="uploads-data.csv" className="download-icon">
-                                <DownloadOutlined title="Export Selected Data as CSV" style={{ fontSize: '24px', transition: 'fill 0.3s', fill: '#000000'}}/>
-                            </CSVLink>
+                            <div className="col-12 col-md-3 count mt-md-3">
+                                <span style={{ marginRight: '1rem' }}>
+                                    {countFilteredRecords(data, filters).length} Selected
+                                </span>
+                                <CSVLink data={countFilteredRecords(data, filters)} filename="uploads-data.csv" className="download-icon">
+                                    <DownloadOutlined title="Export Selected Data as CSV" style={{ fontSize: '24px', transition: 'fill 0.3s', fill: '#000000'}}/>
+                                </CSVLink>
+                            </div>
                         </div>
-                    </div>
-                    <Table className="m-4 UploadTable"
+                    <Table className={`m-4 UploadTable ${countFilteredRecords(data, filters).length > 0 ? '' : 'no-data'}`}
                         columns={uploadColumns}
                         showHeader={!loading}
                         dataSource={data}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -223,6 +223,13 @@ body {
     }
 }
 
+.ant-tooltip {
+    z-index: 9999999999;
+}
+
+.no-data {
+    padding-top: 50px;
+}
 
 /*Hide sorter icon unless moused over*/
 /*.ant-table th .ant-table-column-sorter-up,*/


### PR DESCRIPTION
Changed how urls are handled. Ingest url and organ portal url are now generated on the front-end from uuid rather than being generated on the backend in ingest-api. This change will accompany an update to ingest-api as it will no longer need to generate these and include them in the json. 

Fixed a bug causing a tooltip to appear underneath another element. 

Fixed a bug causing 2 components to overlap in the case where a combination of filters yields no datasets. This interaction occurs because, when there are no results to a combination of filters, the pagination ui is hidden. This moved the table component up such that components clip. This is another one of the unintended side effects of aligning the count selected (and now, export csv button) with the pagination ui. This bug is resolved now as we apply additional padding only in the event of the count being zero and the pagination ui disappearing. 