### PR TITLE
Add cookie domain to match set value from ingest-api

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useEffect, useState, useRef} from 'react'
 import {ENVS, parseJSON, THEME, URLS} from "../service/helper";
 import {useIdleTimer} from 'react-idle-timer'
-import {getCookie, setCookie} from 'cookies-next'
+import {deleteCookie, getCookie, setCookie} from 'cookies-next'
 import axios from "axios";
 
 const AppContext = createContext()
@@ -42,10 +42,9 @@ export const AppProvider = ({ children, messages }) => {
         setGlobusToken(null)
         setGlobusInfo(null)
 
-        setCookie(KEY_AUTH, false)
-        document.cookie.split(";").forEach((c) => {
-            document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/")
-        })
+        deleteCookie(KEY_AUTH)
+        // This cookie was set on login, need to specify the domain to match
+        deleteCookie(KEY_INFO, {path: '/', domain: ENVS.cookieDomain()})
 
         axios.get(URLS.ingest.auth.logout())
             .then( (response) => {

--- a/src/example.env
+++ b/src/example.env
@@ -32,3 +32,6 @@ NEXT_PUBLIC_SEARCH_INDICES = '{"datasets": ["hubmap_id", "data_types", "organ", 
 
 # Uncomment to change auto logout defaults (1000 milliseconds results to 1 hour)
 # NEXT_PUBLIC_IDLE_TIME = 1000
+
+# NEXT_PUBLIC_COOKIE_DOMAIN = localhost
+NEXT_PUBLIC_COOKIE_DOMAIN = .hubmapconsortium.org

--- a/src/example.sennet.env
+++ b/src/example.sennet.env
@@ -32,3 +32,5 @@ NEXT_PUBLIC_SEARCH_INDICES = '{"datasets": ["sennet_id", "data_types", "group_na
 
 # Uncomment to change auto logout defaults (1000 milliseconds results to 1 hour)
 # NEXT_PUBLIC_IDLE_TIME = 1000
+
+NEXT_PUBLIC_COOKIE_DOMAIN = .sennetconsortium.org

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "all": "npm-run-all --parallel dev css",
-    "dev": "next dev --port 3001",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/service/helper.js
+++ b/src/service/helper.js
@@ -88,7 +88,8 @@ export const ENVS = {
             num = Number(num) || 1000
         } catch (e) {}
         return num * 60 * 60
-    }
+    },
+    cookieDomain: () => process.env.NEXT_PUBLIC_COOKIE_DOMAIN
 }
 
 let THEME_CONFIG


### PR DESCRIPTION
Change log:
1. Add path and domain on `deleteCookie` to ensure deletion


**Requires:**
data-ingest-board.env
NEXT_PUBLIC_COOKIE_DOMAIN=.hubmapconsortium.org

ingest-api.app.cfg:
COOKIE_DOMAIN = '.hubmapconsortium.org'