### PR TITLE
Libpitt/116 columns

### DIFF
--- a/src/components/DataTable/DatasetTable.jsx
+++ b/src/components/DataTable/DatasetTable.jsx
@@ -388,6 +388,7 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
                     />
 
                     <Modal
+                        cancelButtonProps={{ style: { display: 'none' } }}
                         open={modalOpen}
                         onCancel={()=> {setModalOpen(false)}}
                         onOk={() => {setModalOpen(false)}}

--- a/src/components/DataTable/UploadTable.jsx
+++ b/src/components/DataTable/UploadTable.jsx
@@ -225,6 +225,7 @@ const UploadTable = ({ data, loading, filterUploads, uploadData, datasetData, ha
                            rowKey={TABLE.cols.f('id')}
                     />
                     <Modal
+                        cancelButtonProps={{ style: { display: 'none' } }}
                         open={modalOpen}
                         onCancel={()=> {setModalOpen(false)}}
                         onOk={() => {setModalOpen(false)}}

--- a/src/components/DataTable/UploadTable.jsx
+++ b/src/components/DataTable/UploadTable.jsx
@@ -76,7 +76,7 @@ const UploadTable = ({ data, loading, filterUploads, uploadData, datasetData, ha
     const uploadColumns = [
         {
             title: TABLE.cols.n('id'),
-            width: '15%',
+            width: 180,
             dataIndex: TABLE.cols.f('id'),
             align: "left",
             defaultSortOrder: defaultSortOrder[TABLE.cols.f('id')] || null,

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -170,37 +170,33 @@ const DataTable = (props) => {
         }
     }
 
-    const toggleApi = () => {
+    const clearBasicFilters = () => {
         setInvalidUploadId(false);
-        setUseDatasetApi(!useDatasetApi);
-        toggleHistory(useDatasetApi)
-        setFilters({});
-        setSortField(undefined);
-        setSortOrder(undefined);
-        setPage(1);
-        setPageSize( 10);
-        // setDatasetCount(primaryData.length);
-        // setUploadCount(uploadData.length);
-    };
-
-    const clearAll = () => {
-        setInvalidUploadId(false);
-        toggleHistory(!useDatasetApi)
-        setPrimaryData(originalPrimaryData);
-        setFilters({});
         if (ENVS.searchEnabled()) {
             applyDatasets(originalResponse.datasets)
             applyUploads(originalResponse.uploads)
             document.getElementById('appSearch').value = ''
         }
+        setFilters({});
         setSortField(undefined);
         setSortOrder(undefined);
         setPage(1);
         setPageSize( 10);
         // setDatasetCount(primaryData.length);
         // setUploadCount(uploadData.length);
-        setTableKey(prevKey => prevKey === 'initialKey' ? 'updatedKey' : 'initialKey');
+    }
 
+    const toggleApi = () => {
+        setUseDatasetApi(!useDatasetApi);
+        toggleHistory(useDatasetApi)
+        clearBasicFilters()
+    };
+
+    const clearAll = () => {
+        toggleHistory(!useDatasetApi)
+        setPrimaryData(originalPrimaryData);
+        clearBasicFilters()
+        setTableKey(prevKey => prevKey === 'initialKey' ? 'updatedKey' : 'initialKey');
     };
 
     const uploadTable = ENVS.uploadsEnabled() ? (


### PR DESCRIPTION
Change log:
1. Hide Cancel button on modal
2. Resolve clearing of filters upon switch between Datasets/Uploads


@maxsibilla @yuanzhou 
@DerekFurstPitt described the following issue to me:

> Starting at the main page (the default view is datasets), if a user enters the hubmap ID of an Upload, obviously, it won't return anything because they are on the dataset view (so far so good, this is expected). If they then click "switch to uploads", and then search for the same upload, the upload appears in the results (still good so far). But then when the user clicks the "show dataset" from the dropdown, it shows no results, even if the upload has datasets that should be returned.

Can you guys help check that all is well with this PR. Thanks! 