### PR TITLE
Account for less than 1 in formatBytes

### DIFF
--- a/src/lib/helpers/general.js
+++ b/src/lib/helpers/general.js
@@ -37,6 +37,7 @@ export const formatNum = (num) => typeof num === 'number' ?  new Intl.NumberForm
 
 export const formatBytes = (bytes, decimals = 2) => {
         if (!+bytes) return '0 Bytes'
+        if (bytes < 1) return `${bytes} Bytes`
 
         const k = 1024
         const dm = decimals < 0 ? 0 : decimals


### PR DESCRIPTION
Just a quick fix for prod to avoid the undefined text for now. 